### PR TITLE
Set verify=False in requests.post

### DIFF
--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -59,7 +59,8 @@ class MailgunBackend(BaseEmailBackend):
                          },
                      files={
                             "message": StringIO(email_message.message().as_string()),
-                         }
+                         },
+                     verify=False
                      )
         except:
             if not self.fail_silently:


### PR DESCRIPTION
Added verify=False to reqeusts.post to avoid the following SSL error:

http://stackoverflow.com/questions/10640546/what-does-this-ssl-error-in-python-mean
