### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -6,7 +6,10 @@ from django.core.mail.message import sanitize_address
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import StringIO
 
 class MailgunAPIError(Exception):
     pass


### PR DESCRIPTION
StringIO moved to the `io` module in Python 3.
