### PR TITLE
A better handling of attachments

### DIFF
--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -56,7 +56,7 @@ class MailgunBackend(BaseEmailBackend):
             post_data.append(('subject', email_message.subject,))
             post_data.append(('from', from_email,))
 
-            if email_message.alternatives:
+            if hasattr(email_message, 'alternatives') and email_message.alternatives:
                 for alt in email_message.alternatives:
                     if alt[1] == 'text/html':
                         post_data.append(('html', alt[0],))

--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -66,8 +66,8 @@ class MailgunBackend(BaseEmailBackend):
             if email_message.attachments:
                 for attachment in email_message.attachments:
                     post_data.append(('attachment', (attachment[0], attachment[1],)))
-                    content, header = encode_multipart_formdata(post_data)
-                    headers = {'Content-Type': header}
+                content, header = encode_multipart_formdata(post_data)
+                headers = {'Content-Type': header}
             else:
                 content = post_data
                 headers = None

--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.message import sanitize_address
 
+from requests.packages.urllib3.filepost import encode_multipart_formdata
+
 class MailgunAPIError(Exception):
     pass
 
@@ -49,7 +51,6 @@ class MailgunBackend(BaseEmailBackend):
 
         try:
 
-            from requests.packages.urllib3.filepost import encode_multipart_formdata
             post_data = []
             post_data.append(('to', (",".join(recipients)),))
             post_data.append(('text', email_message.body,))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CLASSIFIERS = [
 
 setup(
     name='django-mailgun',
-    version='0.2',
+    version='0.2.1',
     packages=['django_mailgun'],
     author='Bradley Whittington',
     author_email='radbrad182@gmail.com',


### PR DESCRIPTION
The prior method did not function very well with HTML emails which also have attachments in them. The Mailgun API allows for these, so I've adjusted to include them.