### PR TITLE
`io` module is present in Python 2.6

### DIFF
--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -4,12 +4,12 @@ from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.message import sanitize_address
 
 try:
-    from cStringIO import StringIO
+    from io import StringIO
 except ImportError:
     try:
-        from StringIO import StringIO
+        from cStringIO import StringIO
     except ImportError:
-        from io import StringIO
+        from StringIO import StringIO
 
 class MailgunAPIError(Exception):
     pass


### PR DESCRIPTION
First import for `StringIO` must be from `io` module because this is the future. Fallback from `cStringIO` and finally from `StringIO` must be for Python 2.5 compatibility. If Python 2.5 is not supported then this `try .. except` block must be removed and only the import from `io` module should be left here.
