### PR TITLE
Code clean up and timeout support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011 Bradley Whittington
+Copyright (c) 2011-2014 Bradley Whittington
  
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,10 @@ Add the following to your settings.py::
     MAILGUN_ACCESS_KEY = 'ACCESS-KEY'
     MAILGUN_SERVER_NAME = 'SERVER-NAME'
 
+Additionally, you can specify max connection time in seconds to avoid blocking of process::
+
+    MAILGUN_TIMEOUT = 200
+
 Now, when you use ``django.core.mail.send_mail``, Mailgun will send the messages
 
 .. _Builtin Email Error Reporting: http://docs.djangoproject.com/en/1.2/howto/error-reporting/

--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -39,6 +39,8 @@ class MailgunBackend(BaseEmailBackend):
             else:
                 raise
 
+        self._connection_timeout = getattr(settings, "MAILGUN_TIMEOUT")
+
         self._api_url = \
             "https://api.mailgun.net/v2/{0}/".format(self._server_name)
 
@@ -71,7 +73,8 @@ class MailgunBackend(BaseEmailBackend):
                 },
                 files={
                     "message": StringIO(email_message.message().as_string()),
-                }
+                },
+                timeout=self._connection_timeout
             )
         except:
             if not self.fail_silently:

--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -1,8 +1,3 @@
-import requests
-from django.conf import settings
-from django.core.mail.backends.base import BaseEmailBackend
-from django.core.mail.message import sanitize_address
-
 try:
     from io import StringIO
 except ImportError:
@@ -11,8 +6,16 @@ except ImportError:
     except ImportError:
         from StringIO import StringIO
 
+import requests
+
+from django.conf import settings
+from django.core.mail.backends.base import BaseEmailBackend
+from django.core.mail.message import sanitize_address
+
+
 class MailgunAPIError(Exception):
     pass
+
 
 class MailgunBackend(BaseEmailBackend):
     """A Django Email backend that uses mailgun.
@@ -21,21 +24,23 @@ class MailgunBackend(BaseEmailBackend):
     def __init__(self, fail_silently=False, *args, **kwargs):
         access_key, server_name = (kwargs.pop('access_key', None),
                                    kwargs.pop('server_name', None))
-    
-        super(MailgunBackend, self).__init__(
-                        fail_silently=fail_silently, 
-                        *args, **kwargs)
+
+        super(MailgunBackend, self).__init__(fail_silently=fail_silently,
+                                             *args, **kwargs)
 
         try:
-            self._access_key = access_key or getattr(settings, 'MAILGUN_ACCESS_KEY')
-            self._server_name = server_name or getattr(settings, 'MAILGUN_SERVER_NAME')
+            self._access_key = access_key or getattr(settings,
+                                                     'MAILGUN_ACCESS_KEY')
+            self._server_name = server_name or getattr(settings,
+                                                       'MAILGUN_SERVER_NAME')
         except AttributeError:
             if fail_silently:
                 self._access_key, self._server_name = None, None
             else:
                 raise
 
-        self._api_url = "https://api.mailgun.net/v2/%s/" % self._server_name
+        self._api_url = \
+            "https://api.mailgun.net/v2/{0}/".format(self._server_name)
 
     def open(self):
         """Stub for open connection, all sends are done over HTTP POSTs
@@ -51,30 +56,31 @@ class MailgunBackend(BaseEmailBackend):
         """A helper method that does the actual sending."""
         if not email_message.recipients():
             return False
-        from_email = sanitize_address(email_message.from_email, email_message.encoding)
+        from_email = sanitize_address(email_message.from_email,
+                                      email_message.encoding)
         recipients = [sanitize_address(addr, email_message.encoding)
                       for addr in email_message.recipients()]
 
         try:
-            r = requests.\
-                post(self._api_url + "messages.mime",
-                     auth=("api", self._access_key),
-                     data={
-                            "to": ", ".join(recipients),
-                            "from": from_email,
-                         },
-                     files={
-                            "message": StringIO(email_message.message().as_string()),
-                         }
-                     )
+            response = requests.post(
+                self._api_url + "messages.mime",
+                auth=("api", self._access_key),
+                data={
+                    "to": ", ".join(recipients),
+                    "from": from_email,
+                },
+                files={
+                    "message": StringIO(email_message.message().as_string()),
+                }
+            )
         except:
             if not self.fail_silently:
                 raise
             return False
 
-        if r.status_code != 200:
+        if response.status_code != 200:
             if not self.fail_silently:
-                raise MailgunAPIError(r)
+                raise MailgunAPIError(response)
             return False
 
         return True

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CLASSIFIERS = [
 
 setup(
     name='django-mailgun',
-    version='0.2.2',
+    version='0.2.3',
     packages=['django_mailgun'],
     author='Bradley Whittington',
     author_email='radbrad182@gmail.com',


### PR DESCRIPTION
Hello

We had problems with blocking processes in our project. Emails were sent using celery, and sometimes all workers become unavailable after sending bunch of emails. I tried some basic testing with requests library and it seems like mailgun got no real timeout, so if connection exists it can last for a while. I've added an option to explicitly specify timeout period using requests' timeout kwarg. It can be None or float value. If connection will not be closed after some reasonable time this option will kill it. I think this option should be helpful, and yet it is optional. 

Also I've some basic PEP8 and clean up of the code and project, hope you will enjoy it.

Logging in celery:
[2014-06-13 07:23:09,034: INFO/Worker-3] Starting new HTTPS connection (1): api.mailgun.net
[2014-06-13 07:23:09,522: WARNING/Worker-3] HTTPSConnectionPool(host='api.mailgun.net', port=443): Request timed out. (timeout=0.0001)