### PR TITLE
Update __init__.py

### DIFF
--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -64,7 +64,7 @@ class MailgunBackend(BaseEmailBackend):
                             "from": from_email,
                          },
                      files={
-                            "message": StringIO(email_message.message().as_string()),
+                            "message": StringIO(unicode(email_message.message().as_string(), errors="ignore")),
                          }
                      )
         except:


### PR DESCRIPTION
Fixed unicode error "initial_value must be None or unicode, not str" which was due to the unicode handling of the email field on python 2.7.7

Out-of-box on django 1.7 with python 2.7.7 we got this error. Provided is the fix that corrected the issue for us.