### PR TITLE
Support  MailGun API V3

### DIFF
--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -35,7 +35,7 @@ class MailgunBackend(BaseEmailBackend):
             else:
                 raise
 
-        self._api_url = "https://api.mailgun.net/v2/%s/" % self._server_name
+        self._api_url = "https://api.mailgun.net/v3/%s/" % self._server_name
 
     def open(self):
         """Stub for open connection, all sends are done over HTTP POSTs


### PR DESCRIPTION
Default API Version for MailGun Now is v3:
http://blog.mailgun.com/default-api-version-now-v3/

Update code to use v3.