### PR TITLE
Fix unicode error in python2.

### DIFF
--- a/django_mailgun/__init__.py
+++ b/django_mailgun/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import requests
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
@@ -21,9 +23,9 @@ class MailgunBackend(BaseEmailBackend):
     def __init__(self, fail_silently=False, *args, **kwargs):
         access_key, server_name = (kwargs.pop('access_key', None),
                                    kwargs.pop('server_name', None))
-    
+
         super(MailgunBackend, self).__init__(
-                        fail_silently=fail_silently, 
+                        fail_silently=fail_silently,
                         *args, **kwargs)
 
         try:


### PR DESCRIPTION
- Revert #13, which breaks python3 since there is no `unicode` built-in.
- Fix python2 unicode issue with [future statement](https://docs.python.org/2/library/__future__.html).
- Remove some random whitespace.