### PR TITLE
added code to pull out recipient variables from header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,3 +29,16 @@ Now, when you use ``django.core.mail.send_mail``, Mailgun will send the messages
 .. _Builtin Email Error Reporting: http://docs.djangoproject.com/en/1.2/howto/error-reporting/
 .. _Django: http://djangoproject.com
 .. _Mailgun: http://mailgun.net
+
+Mailgun also includes the ability to send emails to a group of recipients via a single
+API call (https://documentation.mailgun.com/user_manual.html#batch-sending).  To make use of this,
+you need to pass Recipient Variables along with your API call.  To do so with Django-Mailgun,
+add a valid json string to the `extra_headers` attribute of EmailMessage and Django-Mailgun will
+remove the string from the headers and send it appropriately.  For example::
+
+    email = EmailMessage('Hi!', 'Cool message for %recipient.first_name%', 'admin@example.com', [joe@example.com, jane@example.com])
+    email.extra_headers['recipient_variables'] = '{"joe@example.com":{"first_name":"Joe"}, "jane@example.com":{"first_name:"Jane"}}'
+    email.send()
+
+When Jane receives her email, its body should read 'Cool message for Jane', and Joe will see
+'Cool messagae for Joe'.

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Add the following to your settings.py::
     MAILGUN_ACCESS_KEY = 'ACCESS-KEY'
     MAILGUN_SERVER_NAME = 'SERVER-NAME'
 
-Now, when you use ``django.core.mail.send_mail``, Mailgun will send the messages
+Now, when you use ``django.core.mail.send_mail``, Mailgun will send the messages.
 
 .. _Builtin Email Error Reporting: http://docs.djangoproject.com/en/1.2/howto/error-reporting/
 .. _Django: http://djangoproject.com
@@ -37,7 +37,7 @@ add a valid json string to the `extra_headers` attribute of EmailMessage and Dja
 remove the string from the headers and send it appropriately.  For example::
 
     email = EmailMessage('Hi!', 'Cool message for %recipient.first_name%', 'admin@example.com', [joe@example.com, jane@example.com])
-    email.extra_headers['recipient_variables'] = '{"joe@example.com":{"first_name":"Joe"}, "jane@example.com":{"first_name:"Jane"}}'
+    email.extra_headers['recipient_variables'] = '{"joe@example.com":{"first_name":"Joe"}, "jane@example.com":{"first_name":"Jane"}}'
     email.send()
 
 When Jane receives her email, its body should read 'Cool message for Jane', and Joe will see

--- a/django_mailgun.py
+++ b/django_mailgun.py
@@ -60,6 +60,10 @@ class MailgunBackend(BaseEmailBackend):
             post_data.append(('text', email_message.body,))
             post_data.append(('subject', email_message.subject,))
             post_data.append(('from', from_email,))
+            # get our recipient variables if they were passed in
+            recipient_variables = email_message.extra_headers.pop('recipient_variables', None)
+            if recipient_variables is not None:
+                post_data.append(('recipient-variables', recipient_variables, ))
 
             if hasattr(email_message, 'alternatives') and email_message.alternatives:
                 for alt in email_message.alternatives:


### PR DESCRIPTION
To support batch sending, the API recommends (https://documentation.mailgun.com/user_manual.html#batch-sending) that one should use recipient variables.  I did not know of a cleaner way to implement their sending without modifying other parts of Django, so I added them to the extra_headers attribute on EmailMessage and added code to pop them out in _send().

If there is a better way, please let me know.