### PR TITLE
Add ability to pass in extra tracking options to mailgun via API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,12 @@ Now, when you use ``django.core.mail.send_mail``, Mailgun will send the messages
 .. _Django: http://djangoproject.com
 .. _Mailgun: http://mailgun.net
 
+Extra features
+=================
+
+Passing user-specific data
+--------------------------
+
 Mailgun also includes the ability to send emails to a group of recipients via a single
 API call (https://documentation.mailgun.com/user_manual.html#batch-sending).  To make use of this,
 you need to pass Recipient Variables along with your API call.  To do so with Django-Mailgun,
@@ -40,3 +46,27 @@ remove the string from the headers and send it appropriately.  For example::
 
 When Jane receives her email, its body should read 'Cool message for Jane', and Joe will see
 'Cool messagae for Joe'.
+
+Analytics and other tracking features
+-------------------------------------
+
+Mailgun provides the ability to track certain events that concern your emails. The
+API exposes these options (see https://documentation.mailgun.com/api-sending.html#sending).  These
+options can also be passed to Mailgun's SMTP server (see "Passing Sending Options" under
+https://documentation.mailgun.com/user_manual.html#sending-via-smtp). If you add
+any of the SMTP options to the `extra_headers` attribute of EmailMessage, Django-Mailgun
+will map those values over to the appropriate API parameter. For example::
+
+    email = EmailMessage('Hi!', 'Cool message for Joe', 'admin@example.com', [joe@example.com])
+    email.extra_headers['X-Mailgun-Tag'] = ['Tag 1', 'Tag 2']
+    email.send()
+
+When the email is sent, it will be tagged with 'Tag 1' and 'Tag 2'. You can provide a string for
+any value, or a list or tuple that contains strings for options that can take multiple values.
+
+*NOTE*: Django-Mailgun does **NOT**
+validate your data for compliance with Mailgun's API; it merely maps over whatever values you provide.  For example,
+Mailgun's API states that no more than 3 tags are allowed per email, and each tag must be no greater than
+128 characters (https://documentation.mailgun.com/user_manual.html#tagging).  If you provide 4 tags,
+or a tag longer than 128 characters, Django-Mailgun will attempt to send such (potentially) invalid
+data.  You must ensure what you send is appropriate.

--- a/django_mailgun.py
+++ b/django_mailgun.py
@@ -20,7 +20,7 @@ version = '0.6.0'
 # structure is SMTP_HEADER: (api_name, data_transform_function)
 HEADERS_MAP = {
     'X-Mailgun-Tag': ('o:tag', lambda x: x),
-    'X-Mailgun-Campain-Id': ('o:campain', lambda x: x),
+    'X-Mailgun-Campaign-Id': ('o:campaign', lambda x: x),
     'X-Mailgun-Dkim': ('o:dkim', lambda x: x),
     'X-Mailgun-Deliver-By': ('o:deliverytime', lambda x: x),
     'X-Mailgun-Drop-Message': ('o:testmode', lambda x: x),

--- a/django_mailgun.py
+++ b/django_mailgun.py
@@ -76,7 +76,7 @@ class MailgunBackend(BaseEmailBackend):
         for smtp_key, api_transformer in self._headers_map.iteritems():
             data_to_transform = email_message.extra_headers.pop(smtp_key, None)
             if data_to_transform is not None:
-                api_data.append(api_transformer[0], api_transformer[1](data_to_transform))
+                api_data.append((api_transformer[0], api_transformer[1](data_to_transform)))
         return api_data
 
     def _send(self, email_message):

--- a/test_django_mailgun.py
+++ b/test_django_mailgun.py
@@ -1,7 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 from django.core.mail import EmailMessage
-from django.test import TestCase
 
 from django_mailgun import MailgunBackend
 from pytest import raises
@@ -28,43 +27,43 @@ def test_marker_methods():
     assert mb.close() is None
 
 
-class TestExtraHeaders(TestCase):
+def setUp():
+    mb = MailgunBackend(fail_silently=True)
+    message = EmailMessage()
+    return (mb, message)
 
-    def setUp(self):
-        self.mb = MailgunBackend(fail_silently=True)
-        self.message = EmailMessage()
 
-    def check_output_value(self, test_input, expected_output):
-        for k, v in test_input.iteritems():
-            self.message.extra_headers[k] = v
-        output = self.mb._map_smtp_headers_to_api_parameters()
-        ctr = 0
-        for api_name, api_value in output:
-            self.assertEqual(api_name, expected_output[ctr][0])
-            self.assertEqual(api_value, expected_output[ctr][1])
+def check_output_value(mb, message, test_input, expected_output):
+    for k, v in test_input.iteritems():
+        message.extra_headers[k] = v
+    output = mb._map_smtp_headers_to_api_parameters(message)
+    for extra_header in expected_output:
+        assert extra_header in output
 
-    def test_extra_headers_map(self):
-        test_input = {
-            'X-Mailgun-Tag': ['Tag 1', 'Tag 2'],
-            'X-Mailgun-Campaign-Id': "1",
-            'X-Mailgun-Dkim': 'yes',
-            'X-Mailgun-Deliver-By': 'Thu, 13 Oct 2011 18:02:00 GMT',
-            'X-Mailgun-Drop-Message': 'yes',
-            'X-Mailgun-Track': 'yes',
-            'X-Mailgun-Track-Clicks': 'htmlonly',
-            'X-Mailgun-Track-Opens': 'no',
-            'X-Mailgun-Variables': '{“my_message_id”: 123}',
-        }
-        expected_output = [
-            ('o:tag', 'Tag 1'),
-            ('o:tag', 'Tag 2'),
-            ('o:campaign', '1'),
-            ('o:dkim', 'yes'),
-            ('o:deliverytime', 'Thu, 13 Oct 2011 18:02:00 GMT'),
-            ('o:testmode', 'yes'),
-            ('o:tracking', 'yes'),
-            ('o:tracking-clicks', 'htmlonly'),
-            ('o:tracking-opens', 'no'),
-            ('v:my-var', '{“my_message_id”: 123}'),
-        ]
-        self.check_output_value(test_input, expected_output)
+
+def test_extra_headers_map():
+    mb, message = setUp()
+    test_input = {
+        'X-Mailgun-Tag': ['Tag 1', 'Tag 2'],
+        'X-Mailgun-Campaign-Id': "1",
+        'X-Mailgun-Dkim': 'yes',
+        'X-Mailgun-Deliver-By': 'Thu, 13 Oct 2011 18:02:00 GMT',
+        'X-Mailgun-Drop-Message': 'yes',
+        'X-Mailgun-Track': 'yes',
+        'X-Mailgun-Track-Clicks': 'htmlonly',
+        'X-Mailgun-Track-Opens': 'no',
+        'X-Mailgun-Variables': 'my_message_id: 123',
+    }
+    expected_output = [
+        ('o:tag', 'Tag 1'),
+        ('o:tag', 'Tag 2'),
+        ('o:campaign', '1'),
+        ('o:dkim', 'yes'),
+        ('o:deliverytime', 'Thu, 13 Oct 2011 18:02:00 GMT'),
+        ('o:testmode', 'yes'),
+        ('o:tracking', 'yes'),
+        ('o:tracking-clicks', 'htmlonly'),
+        ('o:tracking-opens', 'no'),
+        ('v:my-var', 'my_message_id: 123'),
+    ]
+    check_output_value(mb, message, test_input, expected_output)

--- a/test_django_mailgun.py
+++ b/test_django_mailgun.py
@@ -1,5 +1,7 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
+from django.core.mail import EmailMessage
+from django.test import TestCase
 
 from django_mailgun import MailgunBackend
 from pytest import raises
@@ -24,3 +26,45 @@ def test_marker_methods():
     mb = MailgunBackend()
     assert mb.open() is None
     assert mb.close() is None
+
+
+class TestExtraHeaders(TestCase):
+
+    def setUp(self):
+        self.mb = MailgunBackend(fail_silently=True)
+        self.message = EmailMessage()
+
+    def check_output_value(self, test_input, expected_output):
+        for k, v in test_input.iteritems():
+            self.message.extra_headers[k] = v
+        output = self.mb._map_smtp_headers_to_api_parameters()
+        ctr = 0
+        for api_name, api_value in output:
+            self.assertEqual(api_name, expected_output[ctr][0])
+            self.assertEqual(api_value, expected_output[ctr][1])
+
+    def test_extra_headers_map(self):
+        test_input = {
+            'X-Mailgun-Tag': ['Tag 1', 'Tag 2'],
+            'X-Mailgun-Campaign-Id': "1",
+            'X-Mailgun-Dkim': 'yes',
+            'X-Mailgun-Deliver-By': 'Thu, 13 Oct 2011 18:02:00 GMT',
+            'X-Mailgun-Drop-Message': 'yes',
+            'X-Mailgun-Track': 'yes',
+            'X-Mailgun-Track-Clicks': 'htmlonly',
+            'X-Mailgun-Track-Opens': 'no',
+            'X-Mailgun-Variables': '{“my_message_id”: 123}',
+        }
+        expected_output = [
+            ('o:tag', 'Tag 1'),
+            ('o:tag', 'Tag 2'),
+            ('o:campaign', '1'),
+            ('o:dkim', 'yes'),
+            ('o:deliverytime', 'Thu, 13 Oct 2011 18:02:00 GMT'),
+            ('o:testmode', 'yes'),
+            ('o:tracking', 'yes'),
+            ('o:tracking-clicks', 'htmlonly'),
+            ('o:tracking-opens', 'no'),
+            ('v:my-var', '{“my_message_id”: 123}'),
+        ]
+        self.check_output_value(test_input, expected_output)


### PR DESCRIPTION
These are some options we need when using mailgun; things like tracking, tagging emails, etc.  Basically, we need the ability to pass options like those found at https://documentation.mailgun.com/user_manual.html#sending-via-smtp via the API (https://documentation.mailgun.com/api-sending.html#sending).  Seemed like if we added the ability, people could pass them in and let an SMTP backend send them or drop in django-mailgun and let it do the same.  I would like to get them included upstream if you feel appropriate.  If anything needs changing, please let me know.  Thanks!