### PR TITLE
support send attachment is instance of MINEBase

### DIFF
--- a/django_mailgun.py
+++ b/django_mailgun.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.message import sanitize_address
 from django.utils.encoding import force_text
+from email.mime.base import MIMEBase
+from email.mime.message import MIMEMessage
 
 from requests.packages.urllib3.filepost import encode_multipart_formdata
 
@@ -134,7 +136,15 @@ class MailgunBackend(BaseEmailBackend):
 
             if email_message.attachments:
                 for attachment in email_message.attachments:
-                    post_data.append(('attachment', (attachment[0], attachment[1],)))
+                    if isinstance(attachment, (tuple, list)):
+                        post_data.append(('attachment', (attachment[0], attachment[1])))
+                    elif isinstance(attachment, MIMEBase):
+                        if "Content-ID" in attachment:
+                            post_data.append(('inline', (attachment["Content-ID"][1:-1], attachment.get_payload(decode=True))))
+                        elif isinstance(attachment, MIMEMessage):
+                            post_data.append(("message", (attachment.get_filename(), attachment.get_payload(decode=True))))
+                        else:
+                            post_data.append(('attachment', (attachment.get_filename(), attachment.get_payload(decode=True))))
                 content, header = encode_multipart_formdata(post_data)
                 headers = {'Content-Type': header}
             else:


### PR DESCRIPTION
According to django document, attribution attachments can be MIMEBase, if don't support that features, I don't know how to send inline attachment. I fix that, It look like work well.