### PR TITLE
Handle multiple user variables with X-Mailgun-Variables header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,28 @@ will map those values over to the appropriate API parameter. For example::
 When the email is sent, it will be tagged with 'Tag 1' and 'Tag 2'. You can provide a string for
 any value, or a list or tuple that contains strings for options that can take multiple values.
 
+Attaching data to messages
+--------------------------
+
+When sending, you can attach data to your messages by passing custom data to X-Mailgun-Variables header
+(see https://documentation.mailgun.com/user_manual.html#attaching-data-to-messages).
+Data should be formatted as JSON, and it will be included in any webhook event releated to the email
+containing the custom data. For example::
+
+    email = EmailMessage('Hi!', 'Cool message for Joe', 'admin@example.com', [joe@example.com])
+    email.extra_headers['X-Mailgun-Variables'] = {'my-id': 'email_id', 'my-variable':'variable'}
+    email.send()
+
+Later, you can read this data in your Mailgun webhook handler. For example::
+
+    def mailgun_webhook(request):
+        email_id = request.data.get('my-id')
+        my_variable = request.data.get('my-variable')
+
+        # Do something with your variables
+
+        return Response(status=status.HTTP_200_OK)
+
 *NOTE*: Django-Mailgun does **NOT**
 validate your data for compliance with Mailgun's API; it merely maps over whatever values you provide.  For example,
 Mailgun's API states that no more than 3 tags are allowed per email, and each tag must be no greater than

--- a/django_mailgun.py
+++ b/django_mailgun.py
@@ -29,7 +29,7 @@ HEADERS_MAP = {
     'X-Mailgun-Track': ('o:tracking', lambda x: x),
     'X-Mailgun-Track-Clicks': ('o:tracking-clicks', lambda x: x),
     'X-Mailgun-Track-Opens': ('o:tracking-opens', lambda x: x),
-    'X-Mailgun-Variables': ('v:my-var', lambda x: x),
+    'X-Mailgun-Variables': lambda (v,k): (('v:%s' % v), k),
 }
 
 
@@ -88,6 +88,9 @@ class MailgunBackend(BaseEmailBackend):
                     # map each value in the tuple/list
                     for data in data_to_transform:
                         api_data.append((api_transformer[0], api_transformer[1](data)))
+                elif type(data_to_transform) == dict:
+                    for data in data_to_transform.iteritems():
+                        api_data.append(api_transformer(data))
                 else:
                     # we only have one value
                     api_data.append((api_transformer[0], api_transformer[1](data_to_transform)))

--- a/django_mailgun.py
+++ b/django_mailgun.py
@@ -84,11 +84,11 @@ class MailgunBackend(BaseEmailBackend):
         for smtp_key, api_transformer in six.iteritems(self._headers_map):
             data_to_transform = email_message.extra_headers.pop(smtp_key, None)
             if data_to_transform is not None:
-                if type(data_to_transform) in (list, tuple):
+                if isinstance(data_to_transform, (list, tuple)):
                     # map each value in the tuple/list
                     for data in data_to_transform:
                         api_data.append((api_transformer[0], api_transformer[1](data)))
-                elif type(data_to_transform) == dict:
+                elif isinstance(data_to_transform, dict):
                     for data in data_to_transform.iteritems():
                         api_data.append(api_transformer(data))
                 else:


### PR DESCRIPTION
In current state it is impossible to send multiple variables for email (header is mapped and variable name is hardcoded as 'my-var'). I updated headers map and mapping function to take JSON object for this header and map this to multiple variables. It's already tested and seems to work correctly. Note: there is no backward compatibility right now.