### PR TITLE
allow for #35 backwards compatability and py3

### DIFF
--- a/django_mailgun.py
+++ b/django_mailgun.py
@@ -29,7 +29,7 @@ HEADERS_MAP = {
     'X-Mailgun-Track': ('o:tracking', lambda x: x),
     'X-Mailgun-Track-Clicks': ('o:tracking-clicks', lambda x: x),
     'X-Mailgun-Track-Opens': ('o:tracking-opens', lambda x: x),
-    'X-Mailgun-Variables': lambda (v,k): (('v:%s' % v), k),
+    'X-Mailgun-Variables': lambda v_k: (('v:%s' % v_k[0]), v_k[1]),
 }
 
 
@@ -89,7 +89,7 @@ class MailgunBackend(BaseEmailBackend):
                     for data in data_to_transform:
                         api_data.append((api_transformer[0], api_transformer[1](data)))
                 elif isinstance(data_to_transform, dict):
-                    for data in data_to_transform.iteritems():
+                    for data in six.iteritems(data_to_transform):
                         api_data.append(api_transformer(data))
                 else:
                     # we only have one value


### PR DESCRIPTION
As per #35, there was no backwards compatibility. I am currently using Python 3.4 which will cause 2 errors with the 1d600e2 commit. I have replaced `iteritems()` to use `six.iteritems()` and followed [PEP-3113](https://www.python.org/dev/peps/pep-3113/) for the tuple unpacking. This currently works for python 3.4 with no change to the code in my app, that is, no additional  `X-Mailgun-Variables` needs to be added to the email header. I have not tested python 2.7.